### PR TITLE
Fix V3025

### DIFF
--- a/FdoToolbox.Base/Forms/FdoSpatialContextDialog.cs
+++ b/FdoToolbox.Base/Forms/FdoSpatialContextDialog.cs
@@ -362,8 +362,7 @@ namespace FdoToolbox.Base.Forms
                         llx, lly,
                         urx, lly,
                         urx, ury,
-                        llx, ury,
-                        llx, lly);
+                        llx, ury);
                 }
                 return sci;
             }
@@ -395,8 +394,7 @@ namespace FdoToolbox.Base.Forms
                         llx, lly,
                         urx, lly,
                         urx, ury,
-                        llx, ury,
-                        llx, lly);
+                        llx, ury);
                 }
                 return sci;
             }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: llx, lly. FdoToolbox.Base FdoSpatialContextDialog.cs 361

- Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: llx, lly. FdoToolbox.Base FdoSpatialContextDialog.cs 394