### PR TITLE
Fix V3025

### DIFF
--- a/FdoToolbox.Express/Controls/CreateRdbmsCtl.cs
+++ b/FdoToolbox.Express/Controls/CreateRdbmsCtl.cs
@@ -241,8 +241,7 @@ namespace FdoToolbox.Express.Controls
                     llx, lly,
                     urx, lly,
                     urx, ury,
-                    llx, ury,
-                    llx, lly);
+                    llx, ury);
             }
             return sc;
         }


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: llx, lly. FdoToolbox.Express CreateRdbmsCtl.cs 240