### PR TITLE
Fix V3025

### DIFF
--- a/Thirdparty/SharpMap/SharpMap/Converters/WellKnownText/CoordinateSystemWktReader.cs
+++ b/Thirdparty/SharpMap/SharpMap/Converters/WellKnownText/CoordinateSystemWktReader.cs
@@ -88,7 +88,7 @@ namespace SharpMap.Converters.WellKnownText
 					returnObject = ReadCoordinateSystem(wkt, tokenizer);
 					break;
 				default:
-					throw new ArgumentException(String.Format("'{0'} is not recongnized.", objectName));
+					throw new ArgumentException(String.Format("{0} is not recongnized.", objectName));
 
 			}
 			reader.Close();


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: objectName. SharpMap CoordinateSystemWktReader.cs 91